### PR TITLE
Compatibility with Ice >= 3.5

### DIFF
--- a/murmur-munin.py
+++ b/murmur-munin.py
@@ -63,6 +63,7 @@ Ice.loadSlice("--all -I%s %s" % (iceincludepath, iceslice))
 props = Ice.createProperties([])
 props.setProperty("Ice.MessageSizeMax", str(messagesizemax))
 props.setProperty("Ice.ImplicitContext", "Shared")
+props.setProperty("Ice.Default.EncodingVersion", "1.0")
 id = Ice.InitializationData()
 id.properties = props
 


### PR DESCRIPTION
After updating Ice to version 3.5.1 and murmur to the latest version the munin-plugin died:
```
Traceback (most recent call last):
File "./murmur-munin.py", line 55, in <module>
meta = Murmur.MetaPrx.checkedCast(ice.stringToProxy("Meta:tcp -h 127.0.0.1 -p %s" % (iceport)))
File "/home/murmur/ice/Murmur.ice", line 4184, in checkedCast

Ice.UnknownLocalException: exception ::Ice::UnknownLocalException
{
unknown = ../../include/Ice/BasicStream.h:175: Ice::UnsupportedEncodingException:
protocol error: unsupported encoding version: 1.1
(can only support encodings compatible with version 1.1)
}
```
I tried all the suggestions on [Natenom´s Wiki (de)](http://wiki.natenom.de/mumble/benutzerhandbuch/murmur/ice#verbindungen_zu_ice) with the following results:

input: `ice="-e 1.0:tcp -h 127.0.0.1 -p 6502"`
outcome: `<C>2015-09-15 21:31:21.087 MurmurIce: Initialization failed: Ice::EndpointParseException`

input: `./murmur.x86 --ice.encodingversion=1.0`
outcome: `<F>2015-09-16 20:54:31.478 Unknown argument --ice.encodingversion=1.0`

I tried several other methods to change the the encoding version to 1.0 but only had luck by adding the following line in the murmur-munin.py:
`props.setProperty("Ice.Default.EncodingVersion", "1.0")`

Maybe you should add this property as a default as long as murmur doesn't support encoding verison 1.1